### PR TITLE
Improved HTML entities parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.0.2",
       "license": "MIT",
       "workspaces": [
+        "./packages/linkifyjs",
+        "./packages/linkify-plugin-*/",
         "./packages/*"
       ],
       "devDependencies": {
@@ -1498,9 +1500,9 @@
       }
     },
     "node_modules/@nfrasser/simple-html-tokenizer": {
-      "version": "0.5.11-1",
-      "resolved": "https://registry.npmjs.org/@nfrasser/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11-1.tgz",
-      "integrity": "sha512-eKOgqGNdsdeeBS/87KWKr1zCEnuOIOEDY0fRmV18iLboKyR1qiTmXE/QqQp9FBC48u/q7kPx9N43SSUKBH5DuQ==",
+      "version": "0.5.11-2",
+      "resolved": "https://registry.npmjs.org/@nfrasser/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11-2.tgz",
+      "integrity": "sha512-ABdeA8BTpHa3p0qC54v5MmZFdyRTJv9DJCtWfizSKdtjSxumXTA8NOnwMAq0oE5ENp1l+N3irfzH6cCCFFkKsQ==",
       "dev": true
     },
     "node_modules/@rollup/plugin-babel": {
@@ -8134,10 +8136,10 @@
       }
     },
     "packages/linkifyjs": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@nfrasser/simple-html-tokenizer": "^0.5.11-1"
+        "@nfrasser/simple-html-tokenizer": "^0.5.11-2"
       }
     }
   },
@@ -9324,9 +9326,9 @@
       "dev": true
     },
     "@nfrasser/simple-html-tokenizer": {
-      "version": "0.5.11-1",
-      "resolved": "https://registry.npmjs.org/@nfrasser/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11-1.tgz",
-      "integrity": "sha512-eKOgqGNdsdeeBS/87KWKr1zCEnuOIOEDY0fRmV18iLboKyR1qiTmXE/QqQp9FBC48u/q7kPx9N43SSUKBH5DuQ==",
+      "version": "0.5.11-2",
+      "resolved": "https://registry.npmjs.org/@nfrasser/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11-2.tgz",
+      "integrity": "sha512-ABdeA8BTpHa3p0qC54v5MmZFdyRTJv9DJCtWfizSKdtjSxumXTA8NOnwMAq0oE5ENp1l+N3irfzH6cCCFFkKsQ==",
       "dev": true
     },
     "@rollup/plugin-babel": {
@@ -11991,7 +11993,7 @@
     "linkifyjs": {
       "version": "file:packages/linkifyjs",
       "requires": {
-        "@nfrasser/simple-html-tokenizer": "^0.5.11-1"
+        "@nfrasser/simple-html-tokenizer": "^0.5.11-2"
       }
     },
     "load-json-file": {

--- a/packages/linkifyjs/package.json
+++ b/packages/linkifyjs/package.json
@@ -34,6 +34,6 @@
   },
   "homepage": "https://github.com/Hypercontext/linkifyjs#readme",
   "devDependencies": {
-    "@nfrasser/simple-html-tokenizer": "^0.5.11-1"
+    "@nfrasser/simple-html-tokenizer": "^0.5.11-2"
   }
 }

--- a/packages/linkifyjs/src/linkify-html.js
+++ b/packages/linkifyjs/src/linkify-html.js
@@ -187,8 +187,10 @@ function skipTagTokens(tagName, tokens, i, skippedTokens) {
 }
 
 function escapeText(text) {
-	// Not required, HTML tokenizer ensures this occurs properly
-	return text;
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
 }
 
 function escapeAttr(attr) {

--- a/test/spec/linkify-html.test.js
+++ b/test/spec/linkify-html.test.js
@@ -33,9 +33,25 @@ describe('linkify-html', () => {
 			'Ignore tags like <script>const a = {}; <a href="http://a.ca">a.ca</a> = "Hello";</script> and <style><a href="http://b.com">b.com</a> {color: blue;}</style>',
 			'Ignore tags like <script>const a = {}; a.ca = "Hello";</script> and <style>b.com {color: blue;}</style>'
 		], [
-			'6. Link followed by nbsp escape sequence https://github.com&nbsp;',
-			'6. Link followed by nbsp escape sequence <a href="https://github.com">https://github.com</a>\u00a0',
-			'6. Link followed by nbsp escape sequence <span href="https://github.com" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">https://github.com</span>\u00a0'
+			'Link followed by nbsp escape sequence https://github.com&nbsp;',
+			'Link followed by nbsp escape sequence <a href="https://github.com">https://github.com</a>\u00a0',
+			'Link followed by nbsp escape sequence <span href="https://github.com" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">https://github.com</span>\u00a0'
+		], [
+			'Link surrounded by encoded quotes &quot;http://google.com&quot;',
+			'Link surrounded by encoded quotes "<a href="http://google.com">http://google.com</a>"',
+			'Link surrounded by encoded quotes "<span href="http://google.com" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">http://google.com</span>"'
+		], [
+			'https:&#x2F;&#x2F;html5-chat.com&#x2F;',
+			'<a href="https://html5-chat.com/">https://html5-chat.com/</a>',
+			'<span href="https://html5-chat.com/" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">https://html5-chat.com/</span>'
+		], [
+			'Surrounded by lt/gt symbols &lt;http://nu.nl&gt;',
+			'Surrounded by lt/gt symbols &lt;<a href="http://nu.nl">http://nu.nl</a>&gt;',
+			'Surrounded by lt/gt symbols &lt;<span href="http://nu.nl" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">http://nu.nl</span>&gt;'
+		], [
+			'http://xml.example.com/pub.dtd?a=1&b=2',
+			'<a href="http://xml.example.com/pub.dtd?a=1&b=2">http://xml.example.com/pub.dtd?a=1&amp;b=2</a>',
+			'<span href="http://xml.example.com/pub.dtd?a=1&b=2" class="my-linkify-class" target="_parent" rel="nofollow" onclick="console.log(\'Hello World!\')">http://xml.example.com/pub.dtd?a=1&amp;b=2</span>'
 		]
 	];
 


### PR DESCRIPTION
With updated simple-html-tokenizer, now correctly handles HTML-encoded `<`, `>`, `"`, and `&` characters. Also correctly handles `&#...` encoded entities.

Fixes #219
Fixes #338
Fixes #350