### PR TITLE
Correctly interpret emoji followed by pound

### DIFF
--- a/packages/linkifyjs/src/scanner.mjs
+++ b/packages/linkifyjs/src/scanner.mjs
@@ -137,11 +137,13 @@ export function init(customSchemes = []) {
 	// Emoji tokens. They are not grouped by the scanner except in cases where a
 	// zero-width joiner is present
 	const Emoji = tr(Start, re.EMOJI, tk.EMOJI, { [fsm.emoji]: true });
+	tt(Emoji, '#'); // no transition, emoji regex seems to match #
 	tr(Emoji, re.EMOJI, Emoji);
 	tt(Emoji, EMOJI_VARIATION, Emoji);
 	// tt(Start, EMOJI_VARIATION, Emoji); // This one is sketchy
 
 	const EmojiJoiner = tt(Emoji, EMOJI_JOINER);
+	tt(EmojiJoiner, '#');
 	tr(EmojiJoiner, re.EMOJI, Emoji);
 	// tt(EmojiJoiner, EMOJI_VARIATION, Emoji); // also sketchy
 

--- a/test/spec/linkify-plugin-hashtag.test.mjs
+++ b/test/spec/linkify-plugin-hashtag.test.mjs
@@ -21,7 +21,7 @@ describe('linkify-plugin-hashtag', () => {
 
 		it('can parse hashtags after applying the plugin', () => {
 			expect(
-				linkify.find('There is a #hashtag #️⃣#YOLO_2015 #__swag__ and #1234 and #%^&*( #_ #__ should not work'),
+				linkify.find('There is a #hashtag 💃#YOLO_2015 #__swag__ and #1234 and #%^&*( #_ #__ should not work'),
 			).to.be.eql([
 				{
 					type: 'hashtag',
@@ -36,16 +36,16 @@ describe('linkify-plugin-hashtag', () => {
 					value: '#YOLO_2015',
 					href: '#YOLO_2015',
 					isLink: true,
-					start: 23,
-					end: 33,
+					start: 22,
+					end: 32,
 				},
 				{
 					type: 'hashtag',
 					value: '#__swag__',
 					href: '#__swag__',
 					isLink: true,
-					start: 34,
-					end: 43,
+					start: 33,
+					end: 42,
 				},
 			]);
 		});

--- a/test/spec/linkify-plugin-hashtag.test.mjs
+++ b/test/spec/linkify-plugin-hashtag.test.mjs
@@ -21,7 +21,7 @@ describe('linkify-plugin-hashtag', () => {
 
 		it('can parse hashtags after applying the plugin', () => {
 			expect(
-				linkify.find('There is a #hashtag #YOLO_2015 #__swag__ and #1234 and #%^&*( #_ #__ should not work'),
+				linkify.find('There is a #hashtag #️⃣#YOLO_2015 #__swag__ and #1234 and #%^&*( #_ #__ should not work'),
 			).to.be.eql([
 				{
 					type: 'hashtag',
@@ -36,16 +36,16 @@ describe('linkify-plugin-hashtag', () => {
 					value: '#YOLO_2015',
 					href: '#YOLO_2015',
 					isLink: true,
-					start: 20,
-					end: 30,
+					start: 23,
+					end: 33,
 				},
 				{
 					type: 'hashtag',
 					value: '#__swag__',
 					href: '#__swag__',
 					isLink: true,
-					start: 31,
-					end: 40,
+					start: 34,
+					end: 43,
 				},
 			]);
 		});

--- a/test/spec/linkifyjs/scanner.test.mjs
+++ b/test/spec/linkifyjs/scanner.test.mjs
@@ -107,6 +107,7 @@ const tests = [
 		[t.UWORD, t.SLASH_SCHEME, t.COLON, t.SLASH, t.SLASH, t.WORD, t.DOT, t.TLD, t.UWORD],
 		['テスト', 'http', ':', '/', '/', 'example', '.', 'com', 'テスト'],
 	],
+	['👻#PhotoOfTheDay', [t.EMOJI, t.POUND, t.WORD], ['👻', '#', 'PhotoOfTheDay']],
 ];
 
 const customSchemeTests = [


### PR DESCRIPTION
So that hashtags preceded by emojis work

Fixes #473