### PR TITLE
Allow parsing magnet links

### DIFF
--- a/packages/linkifyjs/src/parser.mjs
+++ b/packages/linkifyjs/src/parser.mjs
@@ -54,6 +54,7 @@ export function init({ groups }) {
 		tk.COMMA,
 		tk.DOT,
 		tk.EXCLAMATION,
+		tk.PERCENT,
 		tk.QUERY,
 		tk.QUOTE,
 		tk.SEMI,
@@ -211,6 +212,7 @@ export function init({ groups }) {
 	// Force URL with scheme prefix followed by anything sane
 	ta(SchemeColon, groups.domain, Url);
 	tt(SchemeColon, tk.SLASH, Url);
+	tt(SchemeColon, tk.QUERY, Url);
 	ta(UriPrefix, groups.domain, Url);
 	ta(UriPrefix, qsAccepting, Url);
 	tt(UriPrefix, tk.SLASH, Url);

--- a/test/spec/linkifyjs.test.mjs
+++ b/test/spec/linkifyjs.test.mjs
@@ -37,8 +37,9 @@ describe('linkifyjs', () => {
 
 	describe('registerCustomProtocol', () => {
 		beforeEach(() => {
-			linkify.registerCustomProtocol('instagram', true);
 			linkify.registerCustomProtocol('view-source');
+			linkify.registerCustomProtocol('instagram', true);
+			linkify.registerCustomProtocol('magnet', true);
 		});
 
 		it('Detects basic protocol', () => {
@@ -47,6 +48,12 @@ describe('linkifyjs', () => {
 
 		it('Detects basic protocol with slash slash', () => {
 			expect(linkify.test('instagram://user/nfrasser', 'url')).to.be.ok;
+		});
+
+		it('Detects magnet protocol', () => {
+			const magnetLink =
+				'magnet:?xt=urn:btih:5a7f5e0f3ce439e2f1a83e718a8405ec8809110b&dn=ernfkjenrkfk%5FSQ80%5FV%5Fv1.0.0%5Ferfnkerkf%5Ferfnkerkfefrfvegrteggt.net.rar';
+			expect(linkify.test(magnetLink, 'url')).to.be.ok;
 		});
 
 		it('Detects compound protocol', () => {


### PR DESCRIPTION
Fixes #410

Specifically any optionalSlashSlash scheme followed by a question mark, e.g., `magnet:?data...`

Requires registering magnet:

```js
linkify.registerCustomProtocol('magnet', true)
```