### PR TITLE
Fix: allow apostrophe in URL

### DIFF
--- a/packages/linkifyjs/src/parser.mjs
+++ b/packages/linkifyjs/src/parser.mjs
@@ -50,6 +50,7 @@ export function init({ groups }) {
 	// but cannot be the very last characters
 	// Characters that cannot appear in the URL at all should be excluded
 	const qsNonAccepting = [
+		tk.APOSTROPHE,
 		tk.COLON,
 		tk.COMMA,
 		tk.DOT,

--- a/test/spec/linkifyjs/parser.test.mjs
+++ b/test/spec/linkifyjs/parser.test.mjs
@@ -243,9 +243,9 @@ const tests = [
 	],
 	['"https://surrounded.by.quotes/"', [Text, Url, Text], ['"', 'https://surrounded.by.quotes/', '"']],
 	[
-		'More weird character in http://facebook.com/#aZ?/:@-._~!$&()*+,;= that Url',
+		"More weird character in http://facebook.com/#aZ?/:@-._~!$&'()*+,;= that Url",
 		[Text, Url, Text],
-		['More weird character in ', 'http://facebook.com/#aZ?/:@-._~!$&()*+,;=', ' that Url'],
+		['More weird character in ', "http://facebook.com/#aZ?/:@-._~!$&'()*+,;=", ' that Url'],
 	],
 	[
 		'Email with a underscore is n_frasser@example.xyz asd',
@@ -261,11 +261,6 @@ const tests = [
 		"A link in 'singlequote.club/wat' extra fluff at the end",
 		[Text, Url, Text],
 		["A link in '", 'singlequote.club/wat', "' extra fluff at the end"],
-	],
-	[
-		"I really like http://singlequote.club's website design",
-		[Text, Url, Text],
-		['I really like ', 'http://singlequote.club', "'s website design"],
 	],
 	[
 		'Email with mailsomething dot com domain in foo@mailsomething.com',


### PR DESCRIPTION
Hi,  I didn't know that apostrophe was a valid character in a URL up until a person I know told me about it.  

Here's the reference: https://stackoverflow.com/questions/7109143/what-characters-are-valid-in-a-url/7109208#7109208  

I'm sorry.