### PR TITLE
fix: correct text export path from './multi.mjs' to './text.mjs'

### DIFF
--- a/packages/linkifyjs/src/linkify.mjs
+++ b/packages/linkifyjs/src/linkify.mjs
@@ -215,7 +215,7 @@ export function test(str, type = null) {
 export * as options from './options.mjs';
 export * as regexp from './regexp.mjs';
 export * as multi from './multi.mjs';
-export * as text from './multi.mjs';
+export * as text from './text.mjs';
 export { MultiToken, createTokenClass } from './multi.mjs';
 export { stringToArray } from './scanner.mjs';
 export { State } from './fsm.mjs';


### PR DESCRIPTION
## Fix: Correct text export path from './multi.mjs' to './text.mjs'

### Description

This PR fixes an incorrect export statement in linkify.mjs where the `text` namespace was mistakenly exported from multi.mjs instead of text.mjs.

### Problem

Line 218 in linkify.mjs contains an obvious error:

```javascript
export * as text from './multi.mjs';  // ❌ Incorrect
```

This causes the `text` namespace to export the contents of the `multi` module instead of the `text` module, leading to:
- Incorrect API behavior
- Users unable to access text token identifiers defined in text.mjs (such as `WORD`, `UWORD`, `LOCALHOST`, `TLD`, `SCHEME`, etc.)
- Confusion between the `multi` and `text` namespaces

### Solution

Changed the export path to the correct module:

```javascript
export * as text from './text.mjs';  // ✅ Correct
```

### Changes

- **File**: linkify.mjs
- **Line**: 218
- **Change**: Updated path from `'./multi.mjs'` to `'./text.mjs'`

### Impact

After this fix:
- The `text` namespace correctly exports content from text.mjs
- The `multi` and `text` namespaces are now properly separated
- Users can correctly access text token constants:
  ```javascript
  import { text } from 'linkifyjs';
  console.log(text.WORD, text.TLD, text.LOCALHOST); // Works as expected
  ```

### Testing

- [x] Verified the correct file path exists (text.mjs)
- [x] Confirmed the export statement syntax is correct
- [x] No other files are affected by this change