### PR TITLE
fix: detect query string / fragment directly after a domain

### DIFF
--- a/packages/linkifyjs/src/parser.mjs
+++ b/packages/linkifyjs/src/parser.mjs
@@ -191,6 +191,15 @@ export function init({ groups }) {
 	tt(DomainDotTld, tk.SLASH, Url);
 	tt(DomainDotTldColonPort, tk.SLASH, Url);
 
+	// A query string or fragment may also follow the domain (or port) directly,
+	// without a path slash (e.g. `example.com?q=1`, `example.com#frag`). Mirror
+	// how the `Url` state treats these tokens: `?` is non-accepting (a trailing
+	// `?` is trimmed), `#` is accepting.
+	tt(DomainDotTld, tk.QUERY, UrlNonaccept);
+	tt(DomainDotTld, tk.POUND, Url);
+	tt(DomainDotTldColonPort, tk.QUERY, UrlNonaccept);
+	tt(DomainDotTldColonPort, tk.POUND, Url);
+
 	// Note that domains that begin with schemes are treated slighly differently
 	const SchemeColon = tt(Scheme, tk.COLON); // e.g., 'mailto:'
 	const SlashSchemeColon = tt(SlashScheme, tk.COLON); // e.g., 'http:'

--- a/test/spec/linkifyjs/parser.test.mjs
+++ b/test/spec/linkifyjs/parser.test.mjs
@@ -12,6 +12,13 @@ const tests = [
 	['google.com', [Url], ['google.com']],
 	['I like google.com the most', [Text, Url, Text], ['I like ', 'google.com', ' the most']],
 	['I like Google.com the most', [Text, Url, Text], ['I like ', 'Google.com', ' the most']],
+	// Query string / fragment directly after the domain (no path slash) (#516)
+	['example.com?foo=bar', [Url], ['example.com?foo=bar']],
+	['example.com?a=1&b=2', [Url], ['example.com?a=1&b=2']],
+	['example.com:8080?x=1', [Url], ['example.com:8080?x=1']],
+	['example.com#section', [Url], ['example.com#section']],
+	// A trailing `?` is sentence punctuation, not a query string, so it is trimmed
+	['have you seen example.com?', [Text, Url, Text], ['have you seen ', 'example.com', '?']],
 	[
 		'there are two tests, brennan.com and nick.ca -- do they work?',
 		[Text, Url, Text, Url, Text],
@@ -75,8 +82,8 @@ const tests = [
 			' ',
 			'goo.gl/0192n1',
 			' ',
-			'google.com',
-			'?q=asda test ',
+			'google.com?q=asda',
+			' test ',
 			'bit.ly/0912j',
 			' ',
 			'www.bob.com',


### PR DESCRIPTION
## Problem

Fixes #516.

A query string or fragment that comes **directly after the domain**, with no path slash, is dropped:

```js
import { find } from 'linkifyjs';

find('example.com/?foo=bar')[0].href; // http://example.com/?foo=bar  ✅
find('example.com?foo=bar')[0].href;  // http://example.com           ❌ (query dropped)
find('example.com#frag')[0].href;     // http://example.com           ❌ (fragment dropped)
```

## Cause

In the parser state machine, the `DomainDotTld` (e.g. `example.com`) and `DomainDotTldColonPort` (e.g. `example.com:8080`) states only transition into the query-accepting `Url` state on `tk.SLASH`:

```js
tt(DomainDotTld, tk.SLASH, Url);
tt(DomainDotTldColonPort, tk.SLASH, Url);
```

There's no transition on `?` (QUERY) or `#` (POUND), so a `?`/`#` without a preceding `/` ends the match at the bare domain. The scheme-prefixed path already handles this (`tt(SchemeColon, tk.QUERY, Url)`), which is why `http://example.com?x=1` works but `example.com?x=1` doesn't.

## Fix

Add the missing transitions, mirroring how the `Url` state already treats these tokens:

```js
tt(DomainDotTld, tk.QUERY, UrlNonaccept);  // `?` is non-accepting -> trailing `?` stays trimmed
tt(DomainDotTld, tk.POUND, Url);           // `#` is accepting
tt(DomainDotTldColonPort, tk.QUERY, UrlNonaccept);
tt(DomainDotTldColonPort, tk.POUND, Url);
```

Because `QUERY` routes to `UrlNonaccept` (consistent with `qsNonAccepting`), sentence punctuation like `have you seen example.com?` is **not** over-matched — the trailing `?` is still trimmed.

## Test plan

- [x] Added parser cases: `example.com?foo=bar`, `?a=1&b=2`, `:8080?x=1`, `#section` are single `Url` tokens; `have you seen example.com?` keeps the `?` as trailing text.
- [x] Updated one existing case (`google.com?q=asda`) whose expectation encoded the old drop-the-query behavior — it's now a single Url, same token types.
- [x] New cases fail on `main` (5 failing) and pass with the fix.
- [x] Full suite **394 passing**; `eslint` clean.